### PR TITLE
Add vector stacking (concatenating)

### DIFF
--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -205,6 +205,9 @@ proc matrix*[A](xs: seq[seq[A]], order = colMajor): Matrix[A] =
   makeMatrixIJ(A, xs.len, xs[0].len, xs[i][j], order)
 
 proc matrix*[A](xs: seq[Vector[A]], order = colMajor): Matrix[A] =
+  when compileOption("assertions"):
+    for x in xs:
+      checkDim(xs[0].len == x.len, "The dimensions do not match")
   makeMatrixIJ(A, xs.len, xs[0].len, xs[i][j], order)
 
 proc stackMatrix*[M, N: static[int]](a: var DoubleArray32[M, N], order = colMajor): Matrix[float32] =

--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -509,14 +509,14 @@ proc asVector*[A](m: Matrix[A]): Vector[A] =
   else:
     vector(toSeq(m.items))
 
-proc concat*[A](v, w: Vector[A]): Vector[A] =
-  result = vector(concat(v.data, w.data))
+proc concat*[A](vectors: varargs[Vector[A]]): Vector[A] =
+  result = vector(concat(vectors.mapIt(it.data)))
 
-proc hstack*[A](v, w: Vector[A]): Vector[A] =
-  concat(v, w)
+proc hstack*[A](vectors: varargs[Vector[A]]): Vector[A] =
+  concat(vectors)
 
-proc vstack*[A](v, w: Vector[A]): Matrix[A] =
-  matrix(@[v, w])
+proc vstack*[A](vectors: varargs[Vector[A]]): Matrix[A] =
+  matrix(@vectors)
 
 
 # Slice accessors

--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -204,6 +204,9 @@ proc matrix*[A](xs: seq[seq[A]], order = colMajor): Matrix[A] =
       checkDim(xs[0].len == x.len, "The dimensions do not match")
   makeMatrixIJ(A, xs.len, xs[0].len, xs[i][j], order)
 
+proc matrix*[A](xs: seq[Vector[A]], order = colMajor): Matrix[A] =
+  makeMatrixIJ(A, xs.len, xs[0].len, xs[i][j], order)
+
 proc stackMatrix*[M, N: static[int]](a: var DoubleArray32[M, N], order = colMajor): Matrix[float32] =
   let M1: int = if order == colMajor: N else: M
   let N1: int = if order == colMajor: M else: N
@@ -505,6 +508,16 @@ proc asVector*[A](m: Matrix[A]): Vector[A] =
     vector(m.data)
   else:
     vector(toSeq(m.items))
+
+proc concat*[A](v, w: Vector[A]): Vector[A] =
+  result = vector(concat(v.data, w.data))
+
+proc hstack*[A](v, w: Vector[A]): Vector[A] =
+  concat(v, w)
+
+proc vstack*[A](v, w: Vector[A]): Matrix[A] =
+  matrix(@[v, w])
+
 
 # Slice accessors
 

--- a/tests/dense/dstacking.nim
+++ b/tests/dense/dstacking.nim
@@ -1,0 +1,39 @@
+# Copyright 2018 UniCredit S.p.A.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest, neo/dense
+
+proc run() =
+  suite "stacking of vectors":
+    test "concat (horizontal stack) of two vectors":
+      let
+        v1 = vector([1.0, 2.0, 3.0])
+        v2 = vector([5.0, 7.0, 9.0])
+        v = vector([1.0, 2.0, 3.0, 5.0, 7.0, 9.0])
+      check concat(v1, v2) == v
+      check hstack(v1, v2) == v
+
+    test "vertical stack of two vectors":
+      let
+        v1 = vector([1.0, 2.0, 3.0])
+        v2 = vector([5.0, 7.0, 9.0])
+        m = matrix(@[
+          @[1.0, 2.0, 3.0],
+          @[5.0, 7.0, 9.0]
+        ])
+      check matrix(@[v1, v2]) == m
+      check vstack(v1, v2) == m
+
+
+run()

--- a/tests/dense/dstacking.nim
+++ b/tests/dense/dstacking.nim
@@ -18,11 +18,20 @@ proc run() =
   suite "stacking of vectors":
     test "concat (horizontal stack) of two vectors":
       let
-        v1 = vector([1.0, 2.0, 3.0])
+        v1 = vector([1.0, 2.0])
         v2 = vector([5.0, 7.0, 9.0])
-        v = vector([1.0, 2.0, 3.0, 5.0, 7.0, 9.0])
+        v = vector([1.0, 2.0, 5.0, 7.0, 9.0])
       check concat(v1, v2) == v
       check hstack(v1, v2) == v
+
+    test "concat (horizontal stack) of three vectors":
+      let
+        v1 = vector([1.0, 2.0])
+        v2 = vector([5.0, 7.0, 9.0])
+        v3 = vector([9.9, 8.8, 7.7, 6.6])
+        v = vector([1.0, 2.0, 5.0, 7.0, 9.0, 9.9, 8.8, 7.7, 6.6])
+      check concat(v1, v2, v3) == v
+      check hstack(v1, v2, v3) == v
 
     test "vertical stack of two vectors":
       let
@@ -34,6 +43,19 @@ proc run() =
         ])
       check matrix(@[v1, v2]) == m
       check vstack(v1, v2) == m
+
+    test "vertical stack of three vectors":
+      let
+        v1 = vector([1.0, 2.0, 3.0])
+        v2 = vector([5.0, 7.0, 9.0])
+        v3 = vector([9.9, 8.8, 7.7])
+        m = matrix(@[
+          @[1.0, 2.0, 3.0],
+          @[5.0, 7.0, 9.0],
+          @[9.9, 8.8, 7.7]
+        ])
+      check matrix(@[v1, v2, v3]) == m
+      check vstack(v1, v2, v3) == m
 
 
 run()


### PR DESCRIPTION
As discussed in #17.

This adds two new possibilities:
* horizontal stacking (concatenating) of two or more vectors, producing a new (longer) vector
* vertical stacking of two or more vector, producing a matrix where each row is one of the stacked vectors

The first one is achieved by using `sequtils.concat` on underlying data.  
The second one is achieved by allowing matrices to be created from a `seq[Vector]`

The tests were created for the new operations.

(please squash commits when merging to keep things clean)