### PR TITLE
Add getters for mutable elements

### DIFF
--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -264,11 +264,24 @@ proc `[]`*[A](v: Vector[A], i: int): A {. inline .} =
   checkBounds(i >= 0 and i < v.len)
   return cast[CPointer[A]](v.fp)[v.step * i]
 
+proc `[]`*[A](v: var Vector[A], i: int): var A {. inline .} =
+  checkBounds(i >= 0 and i < v.len)
+  return cast[CPointer[A]](v.fp)[v.step * i]
+
 proc `[]=`*[A](v: Vector[A], i: int, val: A) {. inline .} =
   checkBounds(i >= 0 and i < v.len)
   cast[CPointer[A]](v.fp)[v.step * i] = val
 
 proc `[]`*[A](m: Matrix[A], i, j: int): A {. inline .} =
+  checkBounds(i >= 0 and i < m.M)
+  checkBounds(j >= 0 and j < m.N)
+  let mp = cast[CPointer[A]](m.fp)
+  if m.order == colMajor:
+    return elColMajor(mp, m, i, j)
+  else:
+    return elRowMajor(mp, m, i, j)
+
+proc `[]`*[A](m: var Matrix[A], i, j: int): var A {. inline .} =
   checkBounds(i >= 0 and i < m.M)
   checkBounds(j >= 0 and j < m.N)
   let mp = cast[CPointer[A]](m.fp)

--- a/neo/statics.nim
+++ b/neo/statics.nim
@@ -148,6 +148,9 @@ proc len*[N: static[int]; A](v: StaticVector[N, A]): int {. inline .} = N
 proc `[]`*[N: static[int]; A](v: StaticVector[N, A], i: int): A {. inline .} =
   dyn(v, A)[i]
 
+proc `[]`*[N: static[int]; A](v: var StaticVector[N, A], i: int): var A {. inline .} =
+  dyn(v, A)[i]
+
 proc `[]=`*[N: static[int]; A](v: var StaticVector[N, A], i: int, val: A) {. inline .} =
   dyn(v, A)[i] = val
 
@@ -155,6 +158,9 @@ proc dim*[M, N: static[int]; A](m: StaticMatrix[M, N, A]): tuple[rows, columns: 
   (rows: M, columns: N)
 
 proc `[]`*[M, N: static[int]; A](m: StaticMatrix[M, N, A], i, j: int): A {. inline .} =
+  dyn(m, A)[i, j]
+
+proc `[]`*[M, N: static[int]; A](m: var StaticMatrix[M, N, A], i, j: int): var A {. inline .} =
   dyn(m, A)[i, j]
 
 proc `[]=`*[M, N: static[int]; A](m: var StaticMatrix[M, N, A], i, j: int, val: A) {. inline .} =

--- a/tests/dense/daccess.nim
+++ b/tests/dense/daccess.nim
@@ -26,6 +26,12 @@ proc run() =
       check v[2] == 4.0
       check v[3] == 7.0
       check v[4] == 10.0
+    test "mutating vector elements":
+      var v = zeros(3)
+      v[0] += 2.1
+      v[1] -= 1.0
+      check v[0] == 2.1
+      check v[1] == -1.0
     test "writing vector elements":
       var v = zeros(3)
       v[0] = -2.1
@@ -61,6 +67,12 @@ proc run() =
       check m[0, 1] == -2.0
       check m[1, 0] == 3.0
       check m[1, 1] == 1.0
+    test "mutating matrix elements":
+      var m = zeros(3, 3)
+      m[0, 2] += 2.1
+      m[1, 1] -= 1.0
+      check m[0, 2] == 2.1
+      check m[1, 1] == -1.0
     test "writing matrix elements":
       var m = zeros(3, 3)
       m[0, 2] = -2.1

--- a/tests/statics/access.nim
+++ b/tests/statics/access.nim
@@ -26,6 +26,12 @@ proc run() =
       check v[2] == 4.0
       check v[3] == 7.0
       check v[4] == 10.0
+    test "mutating vector elements":
+      var v = zeros(3)
+      v[0] += 2.1
+      v[1] -= 1.0
+      check v[0] == 2.1
+      check v[1] == -1.0
     test "writing vector elements":
       var v = zeros(3)
       v[0] = -2.1
@@ -55,6 +61,12 @@ proc run() =
       check m[0, 1] == -2.0
       check m[1, 0] == 3.0
       check m[1, 1] == 1.0
+    test "mutating matrix elements":
+      var m = zeros(3, 3)
+      m[0, 2] += 2.1
+      m[1, 1] -= 1.0
+      check m[0, 2] == 2.1
+      check m[1, 1] == -1.0
     test "writing matrix elements":
       var m = zeros(3, 3)
       m[0, 2] = -2.1


### PR DESCRIPTION
Should fix #24 

This now works:
```nim
import neo, neo/statics

var v = vector(0)
inc v[0]
v[0] += 1
v[0] *= 2
v[0] -= 1
echo v

var vs = statics.vector([0])
inc vs[0]
vs[0] += 1
vs[0] *= 2
vs[0] -= 1
echo vs

var m = matrix(@[@[0]])
inc m[0, 0]
m[0, 0] += 1
m[0, 0] *= 2
m[0, 0] -= 1
echo m

var ms = statics.matrix([[0]])
inc ms[0, 0]
ms[0, 0] += 1
ms[0, 0] *= 2
ms[0, 0] -= 1
echo ms
```
Implemented using this: https://forum.nim-lang.org/t/4492