### PR TITLE
initialized the default random number generator

### DIFF
--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -17,6 +17,8 @@ import ./core, ./private/neocommon
 export nimblas.OrderType
 export core
 
+randomize() #initializes the default random number generator
+
 type
   MatrixShape* = enum
     Diagonal, UpperTriangular, LowerTriangular, UpperHessenberg, LowerHessenberg, Symmetric


### PR DESCRIPTION
I included the randomize() procedure to initialize the default random number generator, rather than having to do this in my scripts