### PR TITLE
Explicitly compose (relying upon `*` correctness) to test decomposition.

### DIFF
--- a/tests/dense/ddecompositions.nim
+++ b/tests/dense/ddecompositions.nim
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest, neo/dense
-
-proc `~=`(a,b:SomeFloat): bool =
-  abs(a-b) < 1e-2
-
+import unittest, neo/dense, sequtils
 
 proc run() =
   suite "Matrix Decompositions":
@@ -27,27 +23,8 @@ proc run() =
                 @[ -4.75,  8.52,  5.75,  5.30],
                 @[  1.33,  4.91, -5.49, -3.52],
                 @[ -2.40, -6.77,  2.34,  3.95]].matrix
-
-        let expected_U =  @[@[-0.57,  0.18,  0.01,  0.53],
-                          @[ 0.46, -0.11, -0.72,  0.42],
-                          @[-0.45, -0.41,  0.00,  0.36],
-                          @[ 0.33, -0.69,  0.49,  0.19],
-                          @[-0.32, -0.31, -0.28, -0.61],
-                          @[ 0.21,  0.46,  0.39,  0.09]].matrix
-
-        let expected_S = @[@[18.37, 13.63, 10.85, 4.49]].matrix
-
-        let expected_Vh = @[@[-0.52, -0.12,  0.85, -0.03],
-                          @[ 0.08, -0.99, -0.09, -0.01],
-                          @[-0.28, -0.02, -0.14,  0.95],
-                          @[ 0.81,  0.01,  0.50,  0.31]].matrix
     
         let (U, S, Vh) = svd(a)
-        for pos,val in U.pairs:
-          check val ~= expected_U[pos[0],pos[1]]
-        for pos,val in S.pairs:
-          check val ~= expected_S[pos[0],pos[1]]
-        for pos,val in Vh.pairs:
-          check val ~= expected_Vh[pos[0],pos[1]]
+        check U * diag(S.toSeq) * Vh =~ a
 
 run()  


### PR DESCRIPTION
This also lets the test succeed with older versions of Intel MKL.