### PR TITLE
don't give newSeqWith a generic argument

### DIFF
--- a/neo/dense.nim
+++ b/neo/dense.nim
@@ -1415,7 +1415,7 @@ proc symeig*[T: SomeFloat](a: Matrix[T]): (EigenValues[T], EigenVectors[T]) =
 
   result = (
     EigenValues[T](real: w, img: newSeq[T](a.N)),
-    EigenVectors[T](real: distribute(z, a.N).map(x => vector(x)), img: newSeqWith[T](a.N, zeros(a.N)))
+    EigenVectors[T](real: distribute(z, a.N).map(x => vector(x)), img: newSeqWith(a.N, zeros(a.N)))
   )
 
 proc eigenvalues*[A: SomeFloat](a: Matrix[A]): EigenValues[A] =


### PR DESCRIPTION
newSeqWith is a [template](https://nim-lang.org/docs/sequtils.html#newSeqWith.t%2Cint%2Cuntyped) that doesn't take any generic arguments, trying to give it a generic parameter only compiles because of bugs in the Nim compiler.